### PR TITLE
Remove disable3D flag for Chromatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 *.pem
+.tool-versions
 
 # debug
 npm-debug.log*
@@ -33,4 +34,3 @@ build-storybook.log*
 
 # vercel
 .vercel
-

--- a/components/Home/HomePage.stories.tsx
+++ b/components/Home/HomePage.stories.tsx
@@ -21,8 +21,5 @@ export default meta;
 type Story = StoryObj<typeof HomePage>;
 
 export const Default: Story = {
-  name: 'HomePage',
-  args: {
-    disable3D: isChromatic()
-  }
+  name: 'HomePage'
 };

--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -47,11 +47,11 @@ const Divider = () => (
   </Wrapper>
 );
 
-export const HomePage = ({ disable3D = false }: { disable3D?: boolean }) => (
+export const HomePage = () => (
   <>
     <SolidBackdrop>
       <Hero mode={MODE} />
-      {!disable3D ? <BlocksScene /> : <Placeholder>3D placeholder</Placeholder>}
+      <BlocksScene />
     </SolidBackdrop>
     <GradientBackdrop>
       <FeaturesSection />


### PR DESCRIPTION
Chromatic automatically disables canvas elements and leaves empty space so we do not necessarily need to have special handling for it in our code. This PR just drops that from the HomePage story and let's Chromatic do it's own thing with that element.

It also adds `.tool-versions` to the `.gitignore` so I can use asdf with this project.